### PR TITLE
updating moveit.rosinstall

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -2,7 +2,7 @@
 # Used with wstool, users can download source of all packages of MoveIt!.
 - git:
     local-name: moveit
-    uri: https://github.com/ros-planning/moveit.git
+    uri: https://github.com/davetcoleman/moveit.git
     version: kinetic-devel
 - git:
     local-name: moveit_msgs


### PR DESCRIPTION
updating moveit.rosinstall to point to davetcoleman instead of ros-planning.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [ ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!
